### PR TITLE
Improve linux support

### DIFF
--- a/bin/lib/hosts.js
+++ b/bin/lib/hosts.js
@@ -2,15 +2,17 @@
 var fs = require('fs');
 var path = require('path');
 
-var HOSTS = path.join(
-	process.env.SystemRoot || path.join(process.env.SystemDrive || 'C:', 'Windows'),
-	'/System32/drivers/etc/hosts'
-);
+exports.HOSTS = process.platform !== 'win32'
+    ? '/etc/hosts'
+    : path.join(
+        process.env.SystemRoot || path.join(process.env.SystemDrive || 'C:', 'Windows'),
+        '/System32/drivers/etc/hosts',
+    );
 
 exports.get = function () {
 	var lines = [];
 	try {
-		fs.readFileSync(HOSTS, {encoding: 'utf8'})
+		fs.readFileSync(exports.HOSTS, {encoding: 'utf8'})
 		.replace(/\r?\n$/, '')
 		.split(/\r?\n/)
 		.forEach(function (line) {
@@ -79,12 +81,12 @@ exports.writeFile = function (lines) {
 	// Get mode (or set to rw-rw-rw-); check read-only
 	var mode;
 	try {
-		mode = fs.statSync(HOSTS).mode;
-		if (!(mode & 128)) { // 0200 (owner, write)
+		mode = fs.statSync(exports.HOSTS).mode;
+        if (!(mode & 128)) { // 0200 (owner, write)
 			// FIXME generate fake EACCES
 			var err = new Error('EACCES: Permission denied');
 			err.code = 'EACCES';
-			err.path = HOSTS;
+			err.path = exports.HOSTS;
 			throw err;
 		}
 	} catch (e) {
@@ -96,5 +98,5 @@ exports.writeFile = function (lines) {
 	}
 
 	// Write file
-	fs.writeFileSync(HOSTS, data, {mode: mode});
+	fs.writeFileSync(exports.HOSTS, data, {mode: mode});
 };

--- a/bin/lib/hosts.js
+++ b/bin/lib/hosts.js
@@ -81,8 +81,8 @@ exports.writeFile = function (lines) {
 	// Get mode (or set to rw-rw-rw-); check read-only
 	var mode;
 	try {
-		mode = fs.statSync(exports.HOSTS).mode;
-        if (!(mode & 128)) { // 0200 (owner, write)
+		mode = fs.statSync(HOSTS).mode;
+		if (!(mode & 0o200)) { // 0200 (owner, write)
 			// FIXME generate fake EACCES
 			var err = new Error('EACCES: Permission denied');
 			err.code = 'EACCES';
@@ -91,7 +91,7 @@ exports.writeFile = function (lines) {
 		}
 	} catch (e) {
 		if (e.code === 'ENOENT') {
-			mode = 33206; // 0100666 (regular file, rw-rw-rw-)
+			mode = 0o100666; // 0100666 (regular file, rw-rw-rw-)
 		} else {
 			throw e;
 		}
@@ -100,3 +100,13 @@ exports.writeFile = function (lines) {
 	// Write file
 	fs.writeFileSync(exports.HOSTS, data, {mode: mode});
 };
+
+exports.cannotWrite = function() {
+	try {
+		let fd = fs.openSync(exports.HOSTS, 'w+'); // don't set mode (0o100666) to respect umask
+		fs.close(fd);
+		return false;
+	} catch (e) {
+		return e;
+	}
+}

--- a/bin/lib/proxy.js
+++ b/bin/lib/proxy.js
@@ -162,24 +162,17 @@ function listenHandler(err) {
   }
 
   if (!isConsole) {
-    let toSet = [[listenHostname, hostname]];
-    for (let x of altHostnames)
-      toSet.push(listenHostname, x);
+    const toSet = [
+      [listenHostname, hostname],
+      ...altHostnames.map(x => [listenHostname, x])
+    ];
 
     const lines = hosts.get();
-    let toWrite = [];
-    for (let elem of toSet) {
-      let exists = false;
-      for (let line of lines) {
-        if (Array.isArray(line) && line[0] == elem[0] && line[1] == elem[1]) {
-          exists = true;
-          break;
-        }
-      }
-      if (!exists) {
-        toWrite.push(elem);
-      }
-    }
+    const toWrite = toSet.filter(elem => {
+      return !lines.find(line => {
+        return Array.isArray(line) && line[0] == elem[0] && line[1] == elem[1]
+      })
+    });
 
     if (toWrite.length) {
       if (cannotWrite) {

--- a/tera-proxy.sh
+++ b/tera-proxy.sh
@@ -1,0 +1,12 @@
+#/usr/bin/env bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+node="$(command -v node)"
+if command -v node >/dev/null 2>&1
+then
+    cd "$DIR"
+    exec node bin/lib/index.js
+else
+    echo "node.js is required to run this. Consult the package manager of your distro."
+fi


### PR DESCRIPTION
1. Scan for `/etc/hosts` on Linux (or non-Windows) platforms.
2. Only require changing the hosts file when it needs to be modified. Otherwise, just leave it be.
3. In case the file is unwritable on Linux, show what needs to be done to fix it (i.e. run as `sudo` :unamused: or modify `/etc/hosts` manually).

I tried not to mess with the logic too much, like when the hosts file is written, although I did remove the part where the hosts entries are removed *on start*, because they'd get rewritten later anyway, which seems pointless. Instead, just remove entries on exit (this is already the case).