### PR TITLE
Update AA URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This software in this repository does not work in combination with the NA versio
 Almost all tera-proxy modules are compatible with my proxy. For an always up-to-date list, check out [my slack server](https://tinyurl.com/caalitera)!
 * [Skill Prediction (SaltyMonkey's fork, included with the proxy by default)](https://github.com/SaltyMonkey/skill-prediction)
 * [FPS Utils (included with the proxy by default)](https://github.com/codeagon/fps-utils)
-* [Arborean Apparel](https://github.com/codeagon/arborean-apparel)
+* [Arborean Apparel](https://github.com/iribae/arborean-apparel/)
 * [Astral Tera](https://github.com/codeagon/Astral-TERA)
 * [True Everful Nostrum (my fork)](https://github.com/caali-hackerman/true-everful-nostrum)
 * [Instant Soulbind](https://github.com/beng-mods/instant-soulbind)
@@ -59,7 +59,7 @@ Almost all tera-proxy modules are compatible with my proxy. For an always up-to-
 * [No More Death Animations](https://github.com/ayylmar/no-more-death-animations)
 * [Infinity Journal (JustPassingBy's fork)](https://github.com/ayylmar/infinity-journal)
 * [Antaroth's Abyss Guide](https://github.com/Owyn/aaguide)
-* [Tera-Guide](https://github.com/Kaseaa/tera-guide)
+* [Tera-Guide](https://github.com/Kaseaa/tera-guide) (unmaintained)
 * [Mongord](https://github.com/soler91/mongord)
 * [No Drunk Screen](https://github.com/codeagon/no-drunk-screen)
 * [Hide Dmg](https://github.com/soler91/hide-dmg)


### PR DESCRIPTION
This has been thrown around in Discord.

Also mention that tera-guide is unmaintained.