### PR TITLE
Improve Linux support, take 3

### DIFF
--- a/TeraProxy.sh
+++ b/TeraProxy.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-if test "x$(command -v node)" != "x" then
+if test "x$(command -v node)" != "x"; then
   cd "$DIR"
   exec node --use-strict ./bin/index.js
 else

--- a/TeraProxy.sh
+++ b/TeraProxy.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if test "x$(command -v node)" != "x" then
+  cd "$DIR"
+  exec node --use-strict ./bin/index.js
+else
+  echo "ERROR: Node.js is not installed!"
+  echo "ERROR: Please go to http://discord.gg/dUNDDtw and follow the installation guide."
+fi
+
+echo "Press return to continue..."
+read
+

--- a/TeraProxy.sh
+++ b/TeraProxy.sh
@@ -1,14 +1,11 @@
 #!/usr/bin/env bash
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-if test "x$(command -v node)" != "x"; then
+if command -v node > /dev/null 2>&1; then
   cd "$DIR"
   exec node --use-strict ./bin/index.js
 else
   echo "ERROR: Node.js is not installed!"
   echo "ERROR: Please go to http://discord.gg/dUNDDtw and follow the installation guide."
 fi
-
-echo "Press return to continue..."
-read
 

--- a/TeraProxyGUI.sh
+++ b/TeraProxyGUI.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+./node_modules/electron/dist/electron --high-dpi-support=1 --force-device-scale-factor=1 --js-flags="--use-strict" ./bin/index.js &
+

--- a/TeraProxyGUI.sh
+++ b/TeraProxyGUI.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-./node_modules/electron/dist/electron --high-dpi-support=1 --force-device-scale-factor=1 --js-flags="--use-strict" ./bin/index.js &
+exec ./node_modules/electron/dist/electron --high-dpi-support=1 --force-device-scale-factor=1 --js-flags="--use-strict" ./bin/index.js
 

--- a/TeraProxyGUIWithConsole.sh
+++ b/TeraProxyGUIWithConsole.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+./node_modules/electron/dist/electron --high-dpi-support=1 --force-device-scale-factor=1 --js-flags="--use-strict" ./bin/index.js
+
+echo "Press return to continue..."
+read
+

--- a/TeraProxyGUIWithConsole.sh
+++ b/TeraProxyGUIWithConsole.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-cd "$(dirname "${BASH_SOURCE[0]}")"
-
-./node_modules/electron/dist/electron --high-dpi-support=1 --force-device-scale-factor=1 --js-flags="--use-strict" ./bin/index.js
-
-echo "Press return to continue..."
-read
-

--- a/bin/hosts.js
+++ b/bin/hosts.js
@@ -3,11 +3,11 @@ var fs = require('fs');
 var path = require('path');
 
 var HOSTS = process.platform !== 'win32'
-  ? '/etc/hosts'
-  : path.join(
-    process.env.SystemRoot || path.join(process.env.SystemDrive || 'C:', 'Windows'),
-    '/System32/drivers/etc/hosts'
-  );
+	? '/etc/hosts'
+	: path.join(
+		process.env.SystemRoot || path.join(process.env.SystemDrive || 'C:', 'Windows'),
+		'/System32/drivers/etc/hosts'
+	);
 
 exports.get = function () {
 	var lines = [];
@@ -59,28 +59,28 @@ exports.set = function (ip, host) {
 };
 
 exports.setMany = function (hostList) {
-  var lines = exports.get(), host, didUpdate, unchanged = true;
-  // Try to update entries, if host already exists in file
-  for (var i = 0, l = hostList.length; i < l; i++) {
-    didUpdate = false;
-    host = hostList[i];
-    lines = lines.map(function (line) {
-      if (Array.isArray(line) && line[1] === host[1]) {
-        unchanged = (line[0] == host[0]);
-        line[0] = host[0];
-        line[2] = 2; // A flag for error reporting to say this line was changed
-        didUpdate = true;
-      }
-    });
-    
-    // If entry did not exist, let's add it
-    if (!didUpdate) {
-      lines.push([host[0], host[1], 1]); // The 1 is a flag for error reporting to say this line is new
-      unchanged = false;
-    }
-  }
+	var lines = exports.get(), host, didUpdate, unchanged = true;
+	// Try to update entries, if host already exists in file
+	for (var i = 0, l = hostList.length; i < l; i++) {
+		didUpdate = false;
+		host = hostList[i];
+		lines = lines.map(function (line) {
+			if (Array.isArray(line) && line[1] === host[1]) {
+				unchanged = (line[0] == host[0]);
+				line[0] = host[0];
+				line[2] = 2; // A flag for error reporting to say this line was changed
+				didUpdate = true;
+			}
+		});
 
-  if (!unchanged) { exports.writeFile(lines); }
+		// If entry did not exist, let's add it
+		if (!didUpdate) {
+			lines.push([host[0], host[1], 1]); // The 1 is a flag for error reporting to say this line is new
+			unchanged = false;
+		}
+	}
+
+	if (!unchanged) { exports.writeFile(lines); }
 };
 
 exports.remove = function (ip, host) {
@@ -95,17 +95,17 @@ exports.remove = function (ip, host) {
 };
 
 exports.removeMany = function (hostList) {
-  var lines = exports.get(), unchanged = true;
-  
-  // Try to remove entries, if they exist
-  for (let i = 0, l = hostList.length; i < l; i++) {
-    let host = hostList[i];
-    lines = lines.filter(function (line) {
-      return unchanged=!(Array.isArray(line) && line[0] === host[0] && line[1] === host[1]);
-    });
-  }
-  
-  if (!unchanged) { exports.writeFile(lines); }
+	var lines = exports.get(), changed = true;
+
+	// Try to remove entries, if they exist
+	for (let i = 0, l = hostList.length; i < l; i++) {
+		let host = hostList[i];
+		const new_lines = lines.filter((line) => !(Array.isArray(line) && line[0] === host[0] && line[1] === host[1]));
+		changed |= lines.length !== new_lines.length;
+		lines = new_lines;
+	}
+
+	if (changed) { exports.writeFile(lines); }
 };
 
 exports.writeFile = function (lines) {

--- a/bin/hosts.js
+++ b/bin/hosts.js
@@ -2,10 +2,12 @@
 var fs = require('fs');
 var path = require('path');
 
-var HOSTS = path.join(
-	process.env.SystemRoot || path.join(process.env.SystemDrive || 'C:', 'Windows'),
-	'/System32/drivers/etc/hosts'
-);
+var HOST = process.platform !== 'win32'
+  ? '/etc/hosts'
+  : path.join(
+    process.env.SystemRoot || path.join(process.env.SystemDrive || 'C:', 'Windows'),
+    '/System32/drivers/etc/hosts'
+  );
 
 exports.get = function () {
 	var lines = [];
@@ -68,12 +70,12 @@ exports.remove = function (ip, host) {
 };
 
 exports.writeFile = function (lines) {
-	var data = '';
+	var data = '', isWindows == process.platform === 'win32';
 	lines.forEach(function (line) {
 		if (Array.isArray(line)) {
 			line = line[0] + ' ' + line[1];
 		}
-		data += line + '\r\n';
+		data += line + (isWindows ? '\r\n' : '\n');
 	});
 
 	// Get mode (or set to rw-rw-rw-); check read-only

--- a/bin/proxy.js
+++ b/bin/proxy.js
@@ -1,61 +1,52 @@
 // Host file modification
 function HostsError(e) {
-    if (process.platform === 'win32') {
-        switch (e.code) {
-            case "EACCES":
-                console.error('ERROR: Hosts file is set to read-only.');
-                console.error('  * Make sure no anti-virus software is running.')
-                console.error(`  * Locate "${e.path}", right click the file, click 'Properties', uncheck 'Read-only' then click 'OK'.`);
-                break;
-            case "EBUSY":
-                console.error('ERROR: Hosts file is busy and cannot be written to.');
-                console.error('  * Make sure no anti-virus software is running.');
-                console.error(`  * Try deleting "${e.path}".`);
-                break;
-            case "EPERM":
-                console.error('ERROR: Insufficient permission to modify hosts file.');
-                console.error('  * Make sure no anti-virus software is running.');
-                console.error('  * Right click TeraProxy.bat and select \'Run as administrator\'.');
-                break;
-            case "ENOENT":
-                console.error('ERROR: Unable to write to hosts file.');
-                console.error('  * Make sure no anti-virus software is running.');
-                console.error('  * Right click TeraProxy.bat and select \'Run as administrator\'.');
-                break;
+    function printEdits() {
+        if (!e.list) {
+            console.error(`  * Either run with 'sudo' (not recommended) or manually add the hosts to ${e.path}`);
+            return;
         }
-    } else {
-        function printEdits() {
-            if (!e.list) {
-                console.error(`  * Either run with 'sudo' (not recommended) or manually add the hosts to ${e.path}`);
-                return;
-            }
-            console.error(`  * Either run with 'sudo' (not recommended) or change the following in ${e.path}:`);
-            for (var i = 0, list = e.list, l = list.length; i < l; i++) {
-                var entry = list[i];
-                if (entry[2] == 1) { console.error(`Add the line: ${entry[0]} ${entry[1]}`); }
-                else { console.error(`Change the line for ${entry[1]} to: ${entry[0]} ${entry[1]}`); }
-            }
-        }
-        switch (e.code) {
-            case "EACCES":
-                console.error('ERROR: Hosts file is set to read-only.');
-                printEdits();
-                break;
-            case "EBUSY":
-                console.error('ERROR: Hosts file is busy and cannot be written to.');
-                console.error(`  * End any processes locking ${e.path}`);
-                printEdits();
-                break;
-            case "EPERM":
-                console.error('ERROR: Insufficient permission to modify hosts file.');
-                printEdits();
-                break;
-            case "ENOENT":
-                console.error('ERROR: Unable to write to hosts file.');
-                printEdits();
-                break;
+        console.error(`  * Either run with 'sudo' (not recommended) or change the following in ${e.path}:`);
+        for (var i = 0, list = e.list, l = list.length; i < l; i++) {
+            var entry = list[i];
+            if (entry[2] == 1) { console.error(`Add the line: ${entry[0]} ${entry[1]}`); }
+            else { console.error(`Change the line for ${entry[1]} to: ${entry[0]} ${entry[1]}`); }
         }
     }
+    let isWindows = process.platform === 'win32';
+    switch (e.code) {
+        case "EACCES":
+            console.error('ERROR: Hosts file is set to read-only.');
+            if (isWindows) {
+                console.error('  * Make sure no anti-virus software is running.')
+                console.error(`  * Locate "${e.path}", right click the file, click 'Properties', uncheck 'Read-only' then click 'OK'.`);
+            } else { printEdits(); }
+            break;
+        case "EBUSY":
+            console.error('ERROR: Hosts file is busy and cannot be written to.');
+            if (isWindows) {
+                console.error('  * Make sure no anti-virus software is running.');
+                console.error(`  * Try deleting "${e.path}".`);
+            } else {
+                console.error(`  * End any processes locking ${e.path}`);
+                printEdits();
+            }
+            break;
+        case "EPERM":
+            console.error('ERROR: Insufficient permission to modify hosts file.');
+            if (isWindows) {
+                console.error('  * Make sure no anti-virus software is running.');
+                console.error('  * Right click TeraProxy.bat and select \'Run as administrator\'.');
+            } else { printEdits(); }
+            break;
+        case "ENOENT":
+            console.error('ERROR: Unable to write to hosts file.');
+            if (isWindows) {
+                console.error('  * Make sure no anti-virus software is running.');
+                console.error('  * Right click TeraProxy.bat and select \'Run as administrator\'.');
+            } else { printEdits(); }
+            break;
+    }
+
     throw e;
 }
 

--- a/bin/proxy.js
+++ b/bin/proxy.js
@@ -76,7 +76,8 @@ function HostsInitialize(region) {
 }
 
 function HostsClean(region) {
-    if (region && region.platform !== 'console') {
+    // Only clean hosts file on Windows as other platforms (for now) have to do all hosts edits manually
+    if (region && region.platform !== 'console' && process.platform === 'win32') {
         try {
             const hosts = require("./hosts");
             var list = [[region.data.listenHostname, region.data.hostname]];


### PR DESCRIPTION
Like with FichteFoll's PR, this one:
  1. Scans for /etc/hosts on non-Windows platforms
  2. Only writes changes out to the hosts file when changes are really made
  3. Prints out more verbose hosts-related errors on non-Windows machines of what lines need to be added/changed

However, it does it a little differently, and is updated for the current next-gen version.

I replaced (but left in) hosts.js::set and hosts.js::remove with hosts.js::setMany and hosts.js::removeMany. The justification being that this way, all intended writes to the hosts file can be completed in a single write rather than possibly many individual writes. This makes the error reporting easier.

Disabled trying to clean the hosts file on start-up on non-Windows systems as well since it can and most likely will fail, as changes have to be manual and the hosts file will always be "unclean".

Have also included matching shell scripts for each of the batch files.